### PR TITLE
Set minimum SDK to 21 and compile SDK to 26

### DIFF
--- a/src/Uno.Playground.Droid/Properties/AndroidManifest.xml
+++ b/src/Uno.Playground.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.nventive.uno.ui.demo" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="20" />
-  <application android:label="Uno Gallery" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/AppTheme"></application>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.nventive.uno.ui.demo" android:versionCode="1" android:versionName="1.0" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="26" />
+	<application android:label="Uno Gallery" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/AppTheme"></application>
 </manifest>


### PR DESCRIPTION
Minimum SDK was set to 20, which is for Android Wear.
Set compile SDK to 26.

Fixes #15 
